### PR TITLE
Improve typography

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -1,4 +1,4 @@
-\documentclass{modernsimplecv}
+\documentclass[english]{modernsimplecv}
 % try out different fonts: classic, fira, raleway, chivo
 \usepackage[utf8]{inputenc}
 \usepackage[margin=1cm, a4paper]{geometry}
@@ -17,6 +17,26 @@
 \usepackage{beuron}
 \usepackage{LobsterTwo}%if not suposed to be main font, load other main font after this
 
+\frenchspacing
+
+\usepackage[main=english]{babel}
+
+\usepackage[
+  babel=true, % Enable language-specific kerning. Take language-settings from the languge of the current document (see Section 6 of microtype.pdf)
+  expansion=alltext,
+  protrusion=alltext-nott, % Ensure that at listings, there is no change at the margin of the listing
+  final % Always enable microtype, even if in draft mode. This helps finding bad boxes quickly.
+        % In the standard configuration, this template is always in the final mode, so this option only makes a difference if "pros" use the draft mode
+]{microtype}
+
+% \texttt{test -- test} keeps the "--" as "--" (and does not convert it to an en dash)
+\DisableLigatures{encoding = T1, family = tt* }
+
+\usepackage{iftex}
+\ifluatex
+  \usepackage{fontspec}
+  \usepackage{selnolig}
+\fi
 
 
 %------------------------------------------------------------------ Variablen


### PR DESCRIPTION
- No ligatures at "Wortfugen" (works with luatex only) - see [selnolig](https://ctan.org/pkg/selnolig?lang=de) for details
- Optischer Randausgleich und Grauwertkorrektur - see [microtype](https://ctan.org/pkg/microtype?lang=de) for details
- Ensure that normal space at sentence end - see [texfragen](https://texwelt.de/fragen/1154/was-ist-french-spacing-was-macht-frenchspacing) for details. Although I personally really like the slightly larger space, most users do not disable it after abbreviations. Thus, the spacing at "Dr. rer. nat." is really wrong.

Before:

![without-patch](https://user-images.githubusercontent.com/1366654/92298712-1bbac780-ef4c-11ea-8057-2422b15c5806.png)

(sorry for the uncool example word)

![grafik](https://user-images.githubusercontent.com/1366654/92298750-5886be80-ef4c-11ea-8326-553143664304.png)

After:

![grafik](https://user-images.githubusercontent.com/1366654/92298720-27a68980-ef4c-11ea-83b5-b0b9a54a09e0.png)

![grafik](https://user-images.githubusercontent.com/1366654/92298722-2e350100-ef4c-11ea-81c4-6f14be3071c0.png)

